### PR TITLE
Fix unreadable hero text

### DIFF
--- a/wedding_page .htm
+++ b/wedding_page .htm
@@ -31,9 +31,9 @@
     .nav a.btn svg{width:18px;height:18px}
 
     /* HERO */
-    header.hero{position:relative;display:grid;min-height:76vh;align-items:end;color:#fff;background:url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Wedding_Venue.png') center/cover no-repeat}
-    header.hero::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,.25),rgba(0,0,0,.6))}
-    .hero-inner{position:relative;padding:88px 0 64px}
+    header.hero{position:relative;display:grid;min-height:76vh;align-items:end;color:#fff;background:#111 url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Wedding_Venue.png') center/cover no-repeat}
+    header.hero::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,.25),rgba(0,0,0,.6));z-index:0}
+    .hero-inner{position:relative;z-index:1;padding:88px 0 64px}
     .eyebrow{display:inline-block;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.35);backdrop-filter:blur(6px);font-weight:600;letter-spacing:.3px}
     .hero h1{font-family:"Playfair Display",Georgia,serif;font-weight:600;font-size:clamp(36px,6vw,68px);line-height:1.08;margin:14px 0 10px}
     .hero-sub{max-width:760px;font-size:clamp(16px,2vw,19px);opacity:.98;margin:0 0 20px}


### PR DESCRIPTION
## Summary
- add dark fallback background to hero so white text remains readable
- ensure overlay sits behind hero content

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a08da169608322a44af310e8df6e27