### PR TITLE
Fix value pill visibility

### DIFF
--- a/wedding_page .htm
+++ b/wedding_page .htm
@@ -59,7 +59,7 @@
     .bullets li::before{content:"•";position:absolute;left:0;color:var(--gold)}
 
     /* VALUE STRIP */
-    .values{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;margin-top:-28px}
+    .values{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:16px;margin-top:0}
     .pill{background:#fff;color:var(--ink);border:1px solid var(--border);border-radius:999px;padding:10px 14px;display:flex;align-items:center;gap:10px;box-shadow:var(--shadow-sm)}
     .pill svg{width:18px;height:18px;color:var(--gold)}
 


### PR DESCRIPTION
## Summary
- ensure value pills wrap and aren't clipped by switching to an auto-fit grid
- remove negative top margin so pills stay fully visible

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a09197d0148322861bceddbcbc4286