### PR TITLE
Add mobile-friendly guidelines and hero padding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# AGENTS
+
+## Development Guidelines
+- Ensure the site remains mobile friendly across all pages.
+- Hero sections must include horizontal padding on small screens so text does not touch device edges.
+
+## Testing
+- Run `npm test` before committing changes.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
 # Dublincleaners.com
-Revamp of Dublincleaners.com site
+Revamp of Dublincleaners.com site.
+
+## Mobile-Friendly Requirement
+
+- Ensure every page is responsive on mobile devices.
+- The hero section should include horizontal padding so text is not flush against the screen edges on small displays.

--- a/wedding_page .htm
+++ b/wedding_page .htm
@@ -33,7 +33,7 @@
     /* HERO */
     header.hero{position:relative;display:grid;min-height:76vh;align-items:end;color:#fff;background:#111 url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Wedding_Venue.png') center/cover no-repeat}
     header.hero::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,.25),rgba(0,0,0,.6));z-index:0}
-    .hero-inner{position:relative;z-index:1;padding:88px 0 64px}
+    .hero-inner{position:relative;z-index:1;padding:88px 24px 64px}
     .eyebrow{display:inline-block;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.35);backdrop-filter:blur(6px);font-weight:600;letter-spacing:.3px}
     .hero h1{font-family:"Playfair Display",Georgia,serif;font-weight:600;font-size:clamp(36px,6vw,68px);line-height:1.08;margin:14px 0 10px}
     .hero-sub{max-width:760px;font-size:clamp(16px,2vw,19px);opacity:.98;margin:0 0 20px}
@@ -111,7 +111,7 @@
     @media (max-width:980px){
       .grid-2,.grid-3,.contact{grid-template-columns:1fr}
       .bullets{columns:1}
-      .hero-inner{padding:78px 0 46px}
+      .hero-inner{padding:78px 24px 46px}
       .values{grid-template-columns:1fr}
       .nav-inner{padding:8px 0}
     }


### PR DESCRIPTION
## Summary
- document mobile-friendly requirements in repo guidance and README
- pad hero section horizontally so text doesn't touch screen edges on mobile

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0990d0ac88322b2b5b6e4bd92754d