### PR TITLE
Reduce hero section height by 25%

### DIFF
--- a/wedding_page.htm
+++ b/wedding_page.htm
@@ -31,9 +31,9 @@
     .nav a.btn svg{width:18px;height:18px}
 
     /* HERO */
-    header.hero{position:relative;display:grid;min-height:76vh;align-items:end;color:#fff;background:#111 url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Wedding_Venue.png') center/cover no-repeat}
+    header.hero{position:relative;display:grid;min-height:57vh;align-items:end;color:#fff;background:#111 url('https://www.dublincleaners.com/wp-content/uploads/2025/08/Wedding_Venue.png') center/cover no-repeat}
     header.hero::after{content:"";position:absolute;inset:0;background:linear-gradient(180deg,rgba(0,0,0,.25),rgba(0,0,0,.6));z-index:0}
-    .hero-inner{position:relative;z-index:1;padding:88px 24px 64px}
+    .hero-inner{position:relative;z-index:1;padding:66px 24px 48px}
     .eyebrow{display:inline-block;padding:6px 12px;border-radius:999px;background:rgba(255,255,255,.15);border:1px solid rgba(255,255,255,.35);backdrop-filter:blur(6px);font-weight:600;letter-spacing:.3px}
     .hero h1{font-family:"Playfair Display",Georgia,serif;font-weight:600;font-size:clamp(36px,6vw,68px);line-height:1.08;margin:14px 0 10px}
     .hero-sub{max-width:760px;font-size:clamp(16px,2vw,19px);opacity:.98;margin:0 0 20px}
@@ -112,7 +112,7 @@
     @media (max-width:980px){
       .grid-2,.grid-3,.contact{grid-template-columns:1fr}
       .bullets{columns:1}
-      .hero-inner{padding:78px 24px 46px}
+      .hero-inner{padding:58px 24px 34px}
       .values{grid-template-columns:1fr}
       .nav-inner{padding:8px 0}
     }


### PR DESCRIPTION
## Summary
- Shrink hero section height by 25% for a more compact top banner.
- Adjust hero inner padding and responsive values to maintain spacing on smaller screens.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a0c5b5f430832287d4b5985095bfa2